### PR TITLE
Add :escape_only option back in

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -132,6 +132,11 @@ Array of element names to allow. Specify all names in lowercase.
     q s samp small strike strong sub sup time u ul var
   ]
 
+==== :escape_only (boolean)
+
+If set to +true+, Sanitize will escape non-whitelisted elements and their
+contents rather than removing them.
+
 ==== :output (Symbol)
 
 Output format. Supported formats are <code>:html</code> and <code>:xhtml</code>,
@@ -168,6 +173,9 @@ safe parts of an element's contents behind when the element is removed.
 If set to an array of element names, then only the contents of the specified
 elements (when filtered) will be removed, and the contents of all other filtered
 elements will be left behind.
+
+If both <code>:escape_only</code> and <code>:remove_contents</code> are enabled,
+<code>:remove_contents</code> will take precedence.
 
 The default value is <code>false</code>.
 

--- a/lib/sanitize.rb
+++ b/lib/sanitize.rb
@@ -72,6 +72,11 @@ class Sanitize
   def initialize(config = {})
     @config = Config::DEFAULT.merge(config)
 
+    # :remove_contents takes precedence over :escape_only.
+    if @config[:remove_contents] && @config[:escape_only]
+      @config[:escape_only] = false
+    end
+
     @transformers = {
       :breadth => Array(@config[:transformers_breadth].dup),
       :depth   => Array(@config[:transformers]) + Array(@config[:transformers_depth])

--- a/lib/sanitize/config.rb
+++ b/lib/sanitize/config.rb
@@ -41,6 +41,10 @@ class Sanitize
       # that all HTML will be stripped).
       :elements => [],
 
+      # If this is true, Sanitize will escape non-whitelisted elements and their
+      # contents rather than removing them.
+      :escape_only => false,
+
       # Output format. Supported formats are :html and :xhtml. Default is :html.
       :output => :html,
 

--- a/lib/sanitize/transformers/clean_comment.rb
+++ b/lib/sanitize/transformers/clean_comment.rb
@@ -4,7 +4,13 @@ class Sanitize; module Transformers
     return if env[:is_whitelisted]
 
     node = env[:node]
-    node.unlink if node.comment? && !env[:config][:allow_comments]
+    return unless node.comment? && !env[:config][:allow_comments]
+
+    if env[:config][:escape_only]
+      node.replace(Nokogiri::XML::Text.new(node.to_s, node.document))
+    else
+      node.unlink
+    end
   end
 
 end; end

--- a/test/test_sanitize.rb
+++ b/test/test_sanitize.rb
@@ -296,6 +296,23 @@ describe 'Custom configs' do
     Sanitize.clean(html).must_equal("foo\302\240bar")
     Sanitize.clean(html, :output_encoding => 'ASCII').must_equal("foo&#160;bar")
   end
+
+  it 'should escape filtered nodes and their contents when :escape_only == true' do
+    Sanitize.clean('foo bar <div>baz<span>quux</span></div>', :escape_only => true).must_equal('foo bar &lt;div&gt;baz&lt;span&gt;quux&lt;/span&gt;&lt;/div&gt;')
+    Sanitize.clean('foo <!-- comment --> bar', :escape_only => true).must_equal('foo &lt;!-- comment --&gt; bar')
+  end
+
+  it 'should not escape whitelisted nodes when :escape_only == true' do
+    Sanitize.clean('foo bar <div>baz<span>quux</span></div>', :escape_only => true, :elements => ["div"]).must_equal('foo bar <div>baz&lt;span&gt;quux&lt;/span&gt;</div>')
+  end
+
+  it 'should not escape comments when :escape_only == true and :allow_comments == true' do
+    Sanitize.clean('foo <!-- comment --> bar', :escape_only => true, :allow_comments => true).must_equal('foo <!-- comment --> bar')
+  end
+
+  it 'should ensure that :remove_contents takes precedence over :escape_only when both == true' do
+    Sanitize.clean('foo bar <div>baz<span>quux</span></div>', :escape_only => true, :remove_contents => true).must_equal('foo bar   ')
+  end
 end
 
 describe 'Sanitize.clean' do


### PR DESCRIPTION
I came up with a way to avoid double-escaping nested nodes when using :escape_only.

I didn't solve the issue of allowing whitelisted tags inside an escaped node -- that seems to be effectively beyond the range of what Nokogiri offers. I think this behavior will be acceptable for most people wanting this feature, though.
