### PR TITLE
New youtube example.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -289,54 +289,36 @@ your own hands.
 The following example demonstrates how to create a depth-first Sanitize
 transformer that will safely whitelist valid YouTube video embeds without having
 to blindly allow other kinds of embedded content, which would be the case if you
-tried to do this by just whitelisting all <code><object></code>,
-<code><embed></code>, and <code><param></code> elements:
+tried to do this by just whitelisting all <iframe> elements:
 
   lambda do |env|
     node      = env[:node]
     node_name = env[:node_name]
-
+    
     # Don't continue if this node is already whitelisted or is not an element.
     return if env[:is_whitelisted] || !node.element?
 
-    parent = node.parent
-
-    # Since the transformer receives the deepest nodes first, we look for a
-    # <param> element or an <embed> element whose parent is an <object>.
-    return unless (node_name == 'param' || node_name == 'embed') &&
-        parent.name.to_s.downcase == 'object'
-
-    if node_name == 'param'
-      # Quick XPath search to find the <param> node that contains the video URL.
-      return unless movie_node = parent.search('param[@name="movie"]')[0]
-      url = movie_node['value']
-    else
-      # Since this is an <embed>, the video URL is in the "src" attribute. No
-      # extra work needed.
-      url = node['src']
-    end
-
+    # Don't continue unless the node is an iframe.
+    return unless node_name == 'iframe'
+     
     # Verify that the video URL is actually a valid YouTube video URL.
-    return unless url =~ /\Ahttp:\/\/(?:www\.)?youtube\.com\/v\//
-
+    return unless node['src'] =~ /\Ahttp:\/\/(?:www\.)?youtube\.com\//
+    
     # We're now certain that this is a YouTube embed, but we still need to run
     # it through a special Sanitize step to ensure that no unwanted elements or
     # attributes that don't belong in a YouTube embed can sneak in.
-    Sanitize.clean_node!(parent, {
-      :elements => %w[embed object param],
+    Sanitize.clean_node!(node.parent, {
+      :elements => %w[iframe],
 
       :attributes => {
-        'embed'  => %w[allowfullscreen allowscriptaccess height src type width],
-        'object' => %w[height width],
-        'param'  => %w[name value]
+        'iframe'  => %w[allowfullscreen frameborder height src width]
       }
     })
 
     # Now that we're sure that this is a valid YouTube embed and that there are
     # no unwanted elements or attributes hidden inside it, we can tell Sanitize
-    # to whitelist the current node (<param> or <embed>) and its parent
-    # (<object>).
-    {:node_whitelist => [node, parent]}
+    # to whitelist the current node.
+    {:node_whitelist => [node]}
   end
 
 == Contributors


### PR DESCRIPTION
Youtube apparently changed their embed code to use an <iframe> instead of the <embed> tags, so I updated the transformer example in the README to use their new code.
