### PR TITLE
:remove_contents option accepts an array of symbols.

### DIFF
--- a/lib/sanitize/transformers/clean_element.rb
+++ b/lib/sanitize/transformers/clean_element.rb
@@ -14,7 +14,7 @@ class Sanitize; module Transformers
       @whitespace_elements     = Set.new(config[:whitespace_elements])
 
       if config[:remove_contents].is_a?(Array)
-        @remove_element_contents.merge(config[:remove_contents])
+        @remove_element_contents.merge(config[:remove_contents].map(&:to_s))
       else
         @remove_all_contents = !!config[:remove_contents]
       end

--- a/test/test_sanitize.rb
+++ b/test/test_sanitize.rb
@@ -311,8 +311,12 @@ describe 'Custom configs' do
     Sanitize.clean('foo bar <div>baz<span>quux</span></div>', :remove_contents => true).must_equal('foo bar   ')
   end
 
-  it 'should remove the contents of specified nodes when :remove_contents is an Array of element names' do
+  it 'should remove the contents of specified nodes when :remove_contents is an Array of element names as strings' do
     Sanitize.clean('foo bar <div>baz<span>quux</span><script>alert("hello!");</script></div>', :remove_contents => ['script', 'span']).must_equal('foo bar  baz ')
+  end
+
+  it 'should remove the contents of specified nodes when :remove_contents is an Array of element names as symbols' do
+    Sanitize.clean('foo bar <div>baz<span>quux</span><script>alert("hello!");</script></div>', :remove_contents => [:script, :span]).must_equal('foo bar  baz ')
   end
 
   it 'should support encodings other than utf-8' do


### PR DESCRIPTION
I noticed that when I used :remove_contents with an array of symbols, that it did not remove the elements and content. I added a test and corrected it so now you can use both:

:remove_contents => [:title, :a]

-- and --

:remove_contents => ['title', 'a']
