### PR TITLE
Allow anchor links containing colon

### DIFF
--- a/lib/sanitize.rb
+++ b/lib/sanitize.rb
@@ -41,7 +41,7 @@ class Sanitize
   # or more characters followed by a colon is considered a match, even if the
   # colon is encoded as an entity and even if it's an incomplete entity (which
   # IE6 and Opera will still parse).
-  REGEX_PROTOCOL = /\A([^\/]*?)(?:\:|&#0*58|&#x0*3a)/i
+  REGEX_PROTOCOL = /\A([^\/#]*?)(?:\:|&#0*58|&#x0*3a)/i
 
   #--
   # Class Methods

--- a/test/test_sanitize.rb
+++ b/test/test_sanitize.rb
@@ -344,6 +344,16 @@ describe 'Custom configs' do
     Sanitize.clean(input, { :elements => ['a'], :attributes => {'a' => ['href']}, :protocols => { 'a' => { 'href' => [:relative] }} }).must_equal(input)
   end
 
+  it 'should allow relative URLs containing colons where the colon is part of an anchor' do
+    input = '<a href="#fn:1">Footnote 1</a>'
+    Sanitize.clean(input, { :elements => ['a'], :attributes => {'a' => ['href']}, :protocols => { 'a' => { 'href' => [:relative] }} }).must_equal(input)
+  end
+
+  it 'should allow relative URLs containing colons where the colon is part of an anchor' do
+    input = '<a href="somepage#fn:1">Footnote 1</a>'
+    Sanitize.clean(input, { :elements => ['a'], :attributes => {'a' => ['href']}, :protocols => { 'a' => { 'href' => [:relative] }} }).must_equal(input)
+  end
+
   it 'should output HTML when :output == :html' do
     input = 'foo<br/>bar<br>baz'
     Sanitize.clean(input, :elements => ['br'], :output => :html).must_equal('foo<br>bar<br>baz')


### PR DESCRIPTION
A colon is a legitimate character to contain in an ID reference in an
anchor link[1]. The REGEX_PROTOCOL was too general and would consider a
sequence such as '#foo:1' or '/somepage#foo:1' to define the '#foo'
protocol.

The '#' character is explicitly excluded from being part of URI
scheme[2]:

```
  scheme        = alpha *( alpha | digit | "+" | "-" | "." )
```

Therefore it seems safe to exclude the character from the initiali part of REGEX_PROTOCOL. 

[1] http://www.w3.org/TR/html401/types.html#type-name
[2] http://www.ietf.org/rfc/rfc2396.txt
