### PR TITLE
Convert :whitespace_elements into a Hash.

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,15 +209,14 @@ traversal. See the Transformers section below for details.
 Custom transformer or array of custom transformers to run using breadth-first
 traversal. See the Transformers section below for details.
 
-#### :whitespace_elements (Array)
+#### :whitespace_elements (Hash)
 
-Array of lowercase element names that should be replaced with whitespace when
-removed in order to preserve readability. For example,
-`foo<div>bar</div>baz` will become
-`foo bar baz` when the `<div>` is removed.
+Hash of lowercase element names that should be replaced and replacement values
+in order to preserve readability. For example, `foo<div>bar</div>baz` will
+become `foo bar baz` when the `<div>` is removed.
 
-By default, the following elements are included in the
-`:whitespace_elements` array:
+By default, the following elements (as keys) are included in the
+`:whitespace_elements` hash:
 
 ```
 address article aside blockquote br dd div dl dt footer h1 h2 h3 h4 h5

--- a/lib/sanitize/config.rb
+++ b/lib/sanitize/config.rb
@@ -73,14 +73,37 @@ class Sanitize
       :transformers_breadth => [],
 
       # Elements which, when removed, should have their contents surrounded by
-      # space characters to preserve readability. For example,
-      # `foo<div>bar</div>baz` will become 'foo bar baz' when the <div> is
-      # removed.
-      :whitespace_elements => %w[
-        address article aside blockquote br dd div dl dt footer h1 h2 h3 h4 h5
-        h6 header hgroup hr li nav ol p pre section ul
-      ]
-
+      # values specified with `before` and `after` keys to preserve readability.
+      # For example, `foo<div>bar</div>baz` will become 'foo bar baz' when the
+      # <div> is removed.
+      :whitespace_elements => {
+        'address'    => { :before => ' ', :after => ' ' },
+        'article'    => { :before => ' ', :after => ' ' },
+        'aside'      => { :before => ' ', :after => ' ' },
+        'blockquote' => { :before => ' ', :after => ' ' },
+        'br'         => { :before => ' ', :after => ' ' },
+        'dd'         => { :before => ' ', :after => ' ' },
+        'div'        => { :before => ' ', :after => ' ' },
+        'dl'         => { :before => ' ', :after => ' ' },
+        'dt'         => { :before => ' ', :after => ' ' },
+        'footer'     => { :before => ' ', :after => ' ' },
+        'h1'         => { :before => ' ', :after => ' ' },
+        'h2'         => { :before => ' ', :after => ' ' },
+        'h3'         => { :before => ' ', :after => ' ' },
+        'h4'         => { :before => ' ', :after => ' ' },
+        'h5'         => { :before => ' ', :after => ' ' },
+        'h6'         => { :before => ' ', :after => ' ' },
+        'header'     => { :before => ' ', :after => ' ' },
+        'hgroup'     => { :before => ' ', :after => ' ' },
+        'hr'         => { :before => ' ', :after => ' ' },
+        'li'         => { :before => ' ', :after => ' ' },
+        'nav'        => { :before => ' ', :after => ' ' },
+        'ol'         => { :before => ' ', :after => ' ' },
+        'p'          => { :before => ' ', :after => ' ' },
+        'pre'        => { :before => ' ', :after => ' ' },
+        'section'    => { :before => ' ', :after => ' ' },
+        'ul'         => { :before => ' ', :after => ' ' }
+      }
     }
   end
 end

--- a/test/test_sanitize.rb
+++ b/test/test_sanitize.rb
@@ -421,6 +421,21 @@ describe 'Custom configs' do
     Sanitize.clean('<b data-éfoo="valid"></b>', config)
       .must_equal('<b></b>') # Another annoying Nokogiri quirk.
   end
+
+  it 'should replace whitespace_elements with configured :before and :after values' do
+    config = {
+      :whitespace_elements => {
+        'p'   => { :before => "\n", :after => "\n" },
+        'div' => { :before => "\n", :after => "\n" },
+        'br'  => { :before => "\n", :after => "\n" },
+      }
+    }
+
+    Sanitize.clean('<p>foo</p>', config).must_equal("\nfoo\n")
+    Sanitize.clean('<p>foo</p><p>bar</p>', config).must_equal("\nfoo\n\nbar\n")
+    Sanitize.clean('foo<div>bar</div>baz', config).must_equal("foo\nbar\nbaz")
+    Sanitize.clean('foo<br>bar<br>baz', config).must_equal("foo\nbar\nbaz")
+  end
 end
 
 describe 'Sanitize.clean' do
@@ -643,5 +658,18 @@ describe 'bugs' do
   it 'should not have Nokogiri 1.4.2+ unterminated script/style element bug' do
     Sanitize.clean!('foo <script>bar').must_equal('foo bar')
     Sanitize.clean!('foo <style>bar').must_equal('foo bar')
+  end
+end
+
+describe 'backwards compatibility' do
+  it 'should work with legacy :whitespace_elements Arrays' do
+    config = {
+      :whitespace_elements => %w[p div br]
+    }
+
+    Sanitize.clean('<p>foo</p>', config).must_equal(' foo ')
+    Sanitize.clean('<p>foo</p><p>bar</p>', config).must_equal(' foo  bar ')
+    Sanitize.clean('foo<div>bar</div>baz', config).must_equal('foo bar baz')
+    Sanitize.clean('foo<br>bar<br>baz', config).must_equal('foo bar baz')
   end
 end


### PR DESCRIPTION
This will let developers to configure Sanitize to specify the
replacements for :whitespace_elements found in the input. Previously,
developers couldn't specify the text to be inserted before and after
the :whitespace_elements.
- updated :whitespace_elements to be a Hash rather than an Array.
- updated CleanElement#call to use appropriate replacements for the
  element found instead of hardcoded space (' ').
- made sure existing tests were not broken and added new tests for the
  functionality added by overriding replacement values for tags.
- updated README to reflect these changes.

NOTE: Changes are backwards compatible. Code will detect Array types
and will convert them into the new Hash format.
