### PR TITLE
Update Youtube transformer regex to support protocol relative URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ lambda do |env|
   return unless node_name == 'iframe'
 
   # Verify that the video URL is actually a valid YouTube video URL.
-  return unless node['src'] =~ /\A(https?:)?\/\/(?:www\.)?youtube(?:-nocookie)?\.com\//
+  return unless node['src'] =~ %r|\A(?:https?:)?\/\/(?:www\.)?youtube(?:-nocookie)?\.com\/|
 
   # We're now certain that this is a YouTube embed, but we still need to run
   # it through a special Sanitize step to ensure that no unwanted elements or

--- a/test/test_sanitize.rb
+++ b/test/test_sanitize.rb
@@ -514,7 +514,7 @@ describe 'transformers' do
     return unless node_name == 'iframe'
 
     # Verify that the video URL is actually a valid YouTube video URL.
-    return unless node['src'] =~ /\Ahttps?:\/\/(?:www\.)?youtube(?:-nocookie)?\.com\//
+    return unless node['src'] =~ %r|\A(?:https?:)?\/\/(?:www\.)?youtube(?:-nocookie)?\.com\/|
 
     # We're now certain that this is a YouTube embed, but we still need to run
     # it through a special Sanitize step to ensure that no unwanted elements or
@@ -620,6 +620,13 @@ describe 'transformers' do
   it 'should allow https youtube video embeds via the youtube transformer' do
     input  = '<iframe width="420" height="315" src="https://www.youtube.com/embed/QH2-TGUlwu4" frameborder="0" allowfullscreen bogus="bogus"><script>alert()</script></iframe>'
     output = Nokogiri::HTML::DocumentFragment.parse('<iframe width="420" height="315" src="https://www.youtube.com/embed/QH2-TGUlwu4" frameborder="0" allowfullscreen>alert()</iframe>').to_html(:encoding => 'utf-8', :indent => 0)
+
+    Sanitize.clean!(input, :transformers => youtube).must_equal(output)
+  end
+
+  it 'should allow protocol relative youtube video embeds via the youtube transformer' do
+    input  = '<iframe width="420" height="315" src="//www.youtube.com/embed/QH2-TGUlwu4" frameborder="0" allowfullscreen bogus="bogus"><script>alert()</script></iframe>'
+    output = Nokogiri::HTML::DocumentFragment.parse('<iframe width="420" height="315" src="//www.youtube.com/embed/QH2-TGUlwu4" frameborder="0" allowfullscreen>alert()</iframe>').to_html(:encoding => 'utf-8', :indent => 0)
 
     Sanitize.clean!(input, :transformers => youtube).must_equal(output)
   end


### PR DESCRIPTION
I'm currently using Sanitizer for a rails 3.2 application to scrub user submitted HTML coming in via a richtext editor. One notable thing I'm trying to allow is embedding of Youtube videos.

Everything is working as expected, but I noticed the youtube transformer seems to be out of date; it doesn't match protocol relative URLs Youtube is now generating for their embed codes.

I've updated the README and specs with updated regex that will catch protocol relative youtube embed codes in addtion to embed codes over HTTP and HTTPS.
