### PR TITLE
Allow whitespace before protocols.

### DIFF
--- a/lib/sanitize.rb
+++ b/lib/sanitize.rb
@@ -24,7 +24,7 @@ class Sanitize
   # or more characters followed by a colon is considered a match, even if the
   # colon is encoded as an entity and even if it's an incomplete entity (which
   # IE6 and Opera will still parse).
-  REGEX_PROTOCOL = /\A([^\/#]*?)(?:\:|&#0*58|&#x0*3a)/i
+  REGEX_PROTOCOL = /\A\s*([^\/#]*?)(?:\:|&#0*58|&#x0*3a)/i
 
   # Matches Unicode characters that should be stripped from HTML before passing
   # it to the parser.

--- a/test/test_clean_element.rb
+++ b/test/test_clean_element.rb
@@ -154,6 +154,14 @@ describe 'Sanitize::Transformers::CleanElement' do
       :restricted => '',
       :basic      => '',
       :relaxed    => '<img>'
+    },
+
+    'protocol whitespace' => {
+      :html       => '<a href=" http://example.com/"></a>',
+      :default    => '',
+      :restricted => '',
+      :basic      => '<a href="http://example.com/" rel="nofollow"></a>',
+      :relaxed    => '<a href="http://example.com/"></a>'
     }
   }
 


### PR DESCRIPTION
Hi @rgrove,

Thanks for an excellent library!

I recently received a bug report on [Feedbin](https://feedbin.com) about a broken image. The source in the XML looked like:

``` html
<img src="
http://img.thedailywtf.com/images/14/q4/e141/Pic-2.png" />
```

But after it was sanitized it looked like:

``` html
<img>
```

It appears that any attribute that is checked for a valid protocol will be stripped if it contains leading whitespace.

Not sure if this is the right place to address this. The other idea I had was to allow for a regex when specifying allowed protocols like:

``` ruby
protocols: {
  'img' => {'src' => [/\A\s*http/i]}
}
```
