### PR TITLE
Call dup on input to #fragment before preprocessing

### DIFF
--- a/lib/sanitize.rb
+++ b/lib/sanitize.rb
@@ -170,7 +170,7 @@ class Sanitize
 
   # Preprocesses HTML before parsing to remove undesirable Unicode chars.
   def preprocess(html)
-    html.to_s.dup
+    html = html.to_s.dup
 
     unless html.encoding.name == 'UTF-8'
       html.encode!('UTF-8',

--- a/test/test_sanitize.rb
+++ b/test/test_sanitize.rb
@@ -42,6 +42,10 @@ describe 'Sanitize' do
         @s.fragment('<html><body><b>foo</b></body></html>').must_equal 'foo'
         @s.fragment('<!DOCTYPE html><html><body><b>foo</b></body></html>').must_equal 'foo'
       end
+
+      it 'should not choke on fragments which are frozen' do
+        @s.fragment('<b>foo</b>'.freeze).must_equal 'foo'
+      end
     end
 
     describe '#node!' do


### PR DESCRIPTION
The introduction of this #preprocess method in
bf0d753fce1189093155fd5c573c447ce47bdacd broke sanitisation of frozen
strings (for example, hash keys). The reason this was not a problem
previously is that after #preprocess is called, the input is only ever
used by interpolation into another string, so it never matters that the
object is itself frozen.

This patch has the input stringified and duplicated at the start of
preprocessing. I suspect that was already the intent, since this line
of code already stringified and duplicated it, but then threw the
result away. The only actual change here is assigning the result to the
input variable instead.

This commit also adds a test to ensure that #fragment always works on a
frozen input string.