### PR TITLE
Add data-uri image support in the relaxed config

### DIFF
--- a/lib/sanitize/config/relaxed.rb
+++ b/lib/sanitize/config/relaxed.rb
@@ -32,7 +32,7 @@ class Sanitize
 
       :protocols => merge(BASIC[:protocols],
         'del' => {'cite' => ['http', 'https', :relative]},
-        'img' => {'src'  => ['http', 'https', :relative]},
+        'img' => {'src'  => ['http', 'https', 'data', :relative]},
         'ins' => {'cite' => ['http', 'https', :relative]}
       ),
 

--- a/test/test_clean_element.rb
+++ b/test/test_clean_element.rb
@@ -265,6 +265,11 @@ describe 'Sanitize::Transformers::CleanElement' do
         .must_equal '<a href="http://example.com" title="&lt;b&gt;éxamples&lt;/b&gt; &amp; things">foo</a>'
     end
 
+    it 'should allow data-uri protocol in image src values' do
+      @s.fragment('<img src="data:image/gif">')
+        .must_equal '<img src="data:image/gif">'
+    end
+
     strings.each do |name, data|
       it "should clean #{name} HTML" do
         @s.fragment(data[:html]).must_equal(data[:relaxed])


### PR DESCRIPTION
This allows people to provide content that has `<img src="data:image/gif...">` in it. Previously, `<img src="data:image/gif...">` would result in an empty image tag being returned. With this change, the image will actually show up.

Based on preliminary research, I believe this is a safe default and makes sense to be in the core relaxed config. Of course, I trust your judgement and knowledge of the space over my few minutes of googling. :8ball: 

If this doesn't make sense to merge, I can just write up a wiki page showing people how to add this to their custom config.