### PR TITLE
Unpin Nokogumbo version

### DIFF
--- a/sanitize.gemspec
+++ b/sanitize.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   # Runtime dependencies.
   s.add_dependency('crass',     '~> 1.0.2')
   s.add_dependency('nokogiri',  '>= 1.4.4')
-  s.add_dependency('nokogumbo', '1.4.1')
+  s.add_dependency('nokogumbo', '~> 1.4.1')
 
   # Development dependencies.
   s.add_development_dependency('minitest',  '~> 5.6.0')


### PR DESCRIPTION
Is there a reason that you have limited the nokogumbo version to _exactly_ 1.4.1?  Is there a change (either in code or in process) that would enable updated versions to be used?