### PR TITLE
Allow passing methods as transformers to Sanitize constructor

### DIFF
--- a/lib/sanitize.rb
+++ b/lib/sanitize.rb
@@ -77,7 +77,7 @@ class Sanitize
   def initialize(config = {})
     @config = Config.merge(Config::DEFAULT, config)
 
-    @transformers = Array(@config[:transformers])
+    @transformers = Array(@config[:transformers]).dup
 
     # Default transformers always run at the end of the chain, after any custom
     # transformers.

--- a/lib/sanitize.rb
+++ b/lib/sanitize.rb
@@ -77,7 +77,7 @@ class Sanitize
   def initialize(config = {})
     @config = Config.merge(Config::DEFAULT, config)
 
-    @transformers = Array(@config[:transformers].dup)
+    @transformers = Array(@config[:transformers])
 
     # Default transformers always run at the end of the chain, after any custom
     # transformers.

--- a/lib/sanitize/config.rb
+++ b/lib/sanitize/config.rb
@@ -52,7 +52,7 @@ class Sanitize
     # Returns `true` if `dup` may be safely called on _value_, `false`
     # otherwise.
     def self.can_dupe?(value)
-      !(true == value || false == value || value.nil? || Numeric === value || Symbol === value)
+      !(true == value || false == value || value.nil? || Method === value || Numeric === value || Symbol === value)
     end
     private_class_method :can_dupe?
 

--- a/test/test_transformers.rb
+++ b/test/test_transformers.rb
@@ -77,6 +77,12 @@ describe 'Transformers' do
     called.must_equal true
   end
 
+  it 'should accept a method transformer' do
+    def transformer(env); end
+    Sanitize.fragment('<div>foo</div>', :transformers => method(:transformer))
+      .must_equal(' foo ')
+  end
+
   describe 'Image whitelist transformer' do
     require 'uri'
 


### PR DESCRIPTION
Two things needed to be fixed to allow this:

1. Make sure to add `Method` to the checks on classes that you cannot dupe in `Config#can_dupe?`

2. Do not dup transformers in the Sanitize constructor

I made an assumption that you probably do not need to call `#dup` on `@config[:transformers]`. If it's a single callable object, I'm not exactly sure of the use case of `dup`ing it -- unless it's being mutated somewhere. If it's an array of callable objects, then you aren't duping the callable elements anyways.