### PR TITLE
Add srcset to whitelist of img tags

### DIFF
--- a/lib/sanitize/config/relaxed.rb
+++ b/lib/sanitize/config/relaxed.rb
@@ -19,7 +19,7 @@ class Sanitize
         'colgroup' => %w[span width],
         'data'     => %w[value],
         'del'      => %w[cite datetime],
-        'img'      => %w[align alt border height src width],
+        'img'      => %w[align alt border height src srcset width],
         'ins'      => %w[cite datetime],
         'li'       => %w[value],
         'ol'       => %w[reversed start type],


### PR DESCRIPTION
This allows 'retina' images to be embedded at a reasonable scale without having to do annoying things like hardcode a width value.  My motivation is for gitlab markdown, where I want the documentation to inline high-res images straight out of the repository, but at the correct display size.

More information: http://mobile.smashingmagazine.com/2013/08/21/webkit-implements-srcset-and-why-its-a-good-thing/

Browser support: http://caniuse.com/#search=srcset