### PR TITLE
Loosen Nokogumbo version to allow 1.5.0

### DIFF
--- a/sanitize.gemspec
+++ b/sanitize.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   # Runtime dependencies.
   s.add_dependency('crass', '~> 1.0.2')
   s.add_dependency('nokogiri', '>= 1.4.4')
-  s.add_dependency('nokogumbo', '~> 1.4.1')
+  s.add_dependency('nokogumbo', '~> 1.4')
 
   # Development dependencies.
   s.add_development_dependency('minitest', '~> 5.10.2')


### PR DESCRIPTION
On January 27, Nokogumbo 1.5.0 was released. It mainly introduces rubys/nokogumbo#65, which tells Gumbo not no keep track of parse errors. This will reduce memory usage for any Sanitize user dealing with malformed HTML and avoid possible crashes caused by huge number of errors. See pull request for more details.