### PR TITLE
support ruby 2.4+ frozen string literals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,15 @@ language: ruby
 before_install:
   - gem install bundler
 
-rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.3.1
-  - ruby-head
+matrix:
+  include:
+    - os: linux
+      rvm: 1.9.3
+    - os: linux
+      rvm: 2.0.0
+    - os: linux
+      rvm: 2.3.0
+    - os: linux
+      rvm: ruby-head
+      env:
+        - TEST_RUBYOPT_FROZEN_STRING_LITERAL=1

--- a/Rakefile
+++ b/Rakefile
@@ -8,4 +8,9 @@ Bundler::GemHelper.install_tasks
 
 Rake::TestTask.new
 
+if ENV['TEST_RUBYOPT_FROZEN_STRING_LITERAL'] # see .travis.yml
+  ENV['RUBYOPT'] = "--enable-frozen-string-literal --debug=frozen-string-literal"
+  puts "enabling frozen string literals"
+end
+
 task :default => [:test]

--- a/lib/sanitize/css.rb
+++ b/lib/sanitize/css.rb
@@ -255,7 +255,7 @@ class Sanitize; class CSS
     return nil unless @config[:properties].include?(name)
 
     nodes          = prop[:children].dup
-    combined_value = ''
+    combined_value = String.new
 
     nodes.each do |child|
       value = child[:value]

--- a/test/test_sanitize_css.rb
+++ b/test/test_sanitize_css.rb
@@ -181,13 +181,13 @@ describe 'Sanitize::CSS' do
 
     describe '#tree!' do
       it 'should sanitize a Crass CSS parse tree' do
-        tree = Crass.parse("@import url(foo.css);\n" <<
+        tree = Crass.parse(String.new("@import url(foo.css);\n") <<
           ".foo { background: #fff; font: 16pt 'Comic Sans MS'; }\n" <<
           "#bar { top: 125px; background: green; }")
 
         @custom.tree!(tree).must_be_same_as tree
 
-        Crass::Parser.stringify(tree).must_equal "\n" <<
+        Crass::Parser.stringify(tree).must_equal String.new("\n") <<
             ".foo { background: #fff;  }\n" <<
             "#bar {  background: green; }"
       end

--- a/test/test_unicode.rb
+++ b/test/test_unicode.rb
@@ -84,7 +84,7 @@ describe 'Unicode' do
     end
 
     it 'should strip language tag code point characters' do
-      str = 'a'
+      str = String.new 'a'
       (0xE0000..0xE007F).each {|n| str << [n].pack('U') }
       str << 'b'
 


### PR DESCRIPTION
Related to #173, ensure that sanitize support frozen string literals in Ruby 2.4+.

Note that this is different from __enforcing__ frozen string literals.