### PR TITLE
Optimized memory usage

### DIFF
--- a/lib/sanitize.rb
+++ b/lib/sanitize.rb
@@ -198,7 +198,7 @@ class Sanitize
       # the original document didn't actually include a content-type meta tag.
       replace_meta = !@config[:elements].include?('meta') ||
         node.xpath('/html/head/meta[@http-equiv]').none? do |meta|
-          meta['http-equiv'].downcase == 'content-type'
+          meta['http-equiv'].casecmp('content-type').zero?
         end
     end
 
@@ -217,12 +217,14 @@ class Sanitize
   end
 
   def transform_node!(node, node_whitelist)
+    node_name = node.name.downcase
+
     @transformers.each do |transformer|
       result = transformer.call(
         :config         => @config,
         :is_whitelisted => node_whitelist.include?(node),
         :node           => node,
-        :node_name      => node.name.downcase,
+        :node_name      => node_name,
         :node_whitelist => node_whitelist
       )
 

--- a/lib/sanitize/transformers/clean_element.rb
+++ b/lib/sanitize/transformers/clean_element.rb
@@ -99,7 +99,7 @@ class Sanitize; module Transformers; class CleanElement
           if @protocols.include?(name) && @protocols[name].include?(attr_name)
             attr_protocols = @protocols[name][attr_name]
 
-            if attr.value.to_s.downcase =~ REGEX_PROTOCOL
+            if attr.value =~ REGEX_PROTOCOL
               attr.unlink unless attr_protocols.include?($1.downcase)
             else
               attr.unlink unless attr_protocols.include?(:relative)

--- a/test/test_clean_element.rb
+++ b/test/test_clean_element.rb
@@ -402,6 +402,23 @@ describe 'Sanitize::Transformers::CleanElement' do
       s.fragment('foo<div>bar</div>baz').must_equal "foo\nbar\nbaz"
       s.fragment('foo<br>bar<br>baz').must_equal "foo\nbar\nbaz"
     end
-  end
 
+    it 'handles protocols correctly regardless of case' do
+      input = '<a href="hTTpS://foo.com/">Text</a>'
+
+      Sanitize.fragment(input, {
+        :elements   => ['a'],
+        :attributes => {'a' => ['href']},
+        :protocols  => {'a' => {'href' => ['https']}}
+      }).must_equal input
+
+      input = '<a href="mailto:someone@example.com?Subject=Hello">Text</a>'
+
+      Sanitize.fragment(input, {
+        :elements   => ['a'],
+        :attributes => {'a' => ['href']},
+        :protocols  => {'a' => {'href' => ['https']}}
+      }).must_equal "<a>Text</a>"
+    end
+  end
 end


### PR DESCRIPTION
Following up on https://github.com/rgrove/sanitize/issues/173 I found some ways to make `sanitize` allocate less objects/memory (and added some basic Rubocop-driven cleanup).

The most effective change is that `node_name` is created only once in `transform_node!` (while previously it was allocated once per each transformer). In my quick test, this leads to significant savings.

**Before**
![screen shot 2018-03-19 at 11 31 16 pm](https://user-images.githubusercontent.com/7811733/37608686-c6a8b7c8-2bcd-11e8-99c0-f5800f514739.png)
![screen shot 2018-03-19 at 11 31 28 pm](https://user-images.githubusercontent.com/7811733/37608690-c9282cfe-2bcd-11e8-9f01-a8cec73e7366.png)
![screen shot 2018-03-19 at 11 31 47 pm](https://user-images.githubusercontent.com/7811733/37608693-cb6d1da8-2bcd-11e8-9e68-4ae32386f1ae.png)

**After**
![screen shot 2018-03-19 at 11 34 46 pm](https://user-images.githubusercontent.com/7811733/37608866-380ebf52-2bce-11e8-8738-bf3def18618f.png)
![screen shot 2018-03-19 at 11 34 58 pm](https://user-images.githubusercontent.com/7811733/37608869-3a86a218-2bce-11e8-872f-eea1bc666c69.png)
![screen shot 2018-03-19 at 11 35 15 pm](https://user-images.githubusercontent.com/7811733/37608875-3cc5bb86-2bce-11e8-9472-22dfad1c7de1.png)

That amounts to 5.3MB less memory allocated, i.e. saving of ~16%.

