### PR TITLE
Clean elements before cleaning styles

### DIFF
--- a/lib/sanitize.rb
+++ b/lib/sanitize.rb
@@ -81,6 +81,7 @@ class Sanitize
 
     # Default transformers always run at the end of the chain, after any custom
     # transformers.
+    @transformers << Transformers::CleanElement.new(@config)
     @transformers << Transformers::CleanComment unless @config[:allow_comments]
 
     if @config[:elements].include?('style')
@@ -95,8 +96,7 @@ class Sanitize
 
     @transformers <<
         Transformers::CleanDoctype <<
-        Transformers::CleanCDATA <<
-        Transformers::CleanElement.new(@config)
+        Transformers::CleanCDATA
   end
 
   # Returns a sanitized copy of the given _html_ document.


### PR DESCRIPTION
So CPU will no longer be wasted cleaning `style=""` attributes on non-permitted elements, nor cleaning `<style>` contents if `<style>` elements are not permitted.

I haven’t created a benchmark or sample script to prove the above claim, but looking at the code it seems pretty clear what’s happening. I made the change and all specs were still green, so I figured I would just submit this as-is.