### PR TITLE
Clarifies whitespace_elements documentation to specify default elements with whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,15 @@ children, in which case it will be inserted after those children.
 }
 ```
 
+The default elements with whitespace added before and after are:
+
+```
+address article aside blockquote br dd div dl dt
+footer h1 h2 h3 h4 h5 h6 header hgroup hr li nav
+ol p pre section ul
+
+```
+
 ## Transformers
 
 Transformers allow you to filter and modify HTML nodes using your own custom


### PR DESCRIPTION
I added some documentation clarifying that there are some elements that have whitespace added before and after when they are removed. I couldn't figure out why I had whitespace being added when p tags were removed while using Sanitize and couldnt find anything in the documentation that specified defaults. After digging into the code I saw that there were several defaults and wanted to help anyone else that might get confused in the future.