### PR TITLE
Update to Nokogumbo 2.0

### DIFF
--- a/sanitize.gemspec
+++ b/sanitize.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   # Runtime dependencies.
   s.add_dependency('crass', '~> 1.0.2')
   s.add_dependency('nokogiri', '>= 1.4.4')
-  s.add_dependency('nokogumbo', '~> 1.4')
+  s.add_dependency('nokogumbo', '~> 2.0')
 
   # Development dependencies.
   s.add_development_dependency('minitest', '~> 5.10.2')

--- a/test/test_clean_css.rb
+++ b/test/test_clean_css.rb
@@ -13,7 +13,7 @@ describe 'Sanitize::Transformers::CSS::CleanAttribute' do
     @s.fragment(%[
       <div style="color: #fff; width: expression(alert(1)); /* <-- evil! */"></div>
     ].strip).must_equal %[
-      <div style="color: #fff;  /* &lt;-- evil! */"></div>
+      <div style="color: #fff;  /* <-- evil! */"></div>
     ].strip
   end
 

--- a/test/test_clean_doctype.rb
+++ b/test/test_clean_doctype.rb
@@ -11,7 +11,7 @@ describe 'Sanitize::Transformers::CleanDoctype' do
     end
 
     it 'should remove doctype declarations' do
-      @s.document('<!DOCTYPE html><html>foo</html>').must_equal "<html>foo</html>\n"
+      @s.document('<!DOCTYPE html><html>foo</html>').must_equal "<html>foo</html>"
       @s.fragment('<!DOCTYPE html>foo').must_equal 'foo'
     end
 
@@ -34,27 +34,27 @@ describe 'Sanitize::Transformers::CleanDoctype' do
 
     it 'should allow doctype declarations in documents' do
       @s.document('<!DOCTYPE html><html>foo</html>')
-        .must_equal "<!DOCTYPE html>\n<html>foo</html>\n"
+        .must_equal "<!DOCTYPE html><html>foo</html>"
 
       @s.document('<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN"><html>foo</html>')
-        .must_equal "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01//EN\">\n<html>foo</html>\n"
+        .must_equal "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01//EN\"><html>foo</html>"
 
       @s.document("<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\"\n    \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\"><html>foo</html>")
-        .must_equal "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n<html>foo</html>\n"
+        .must_equal "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\"><html>foo</html>"
     end
 
     it 'should not allow obviously invalid doctype declarations in documents' do
       @s.document('<!DOCTYPE blah blah blah><html>foo</html>')
-        .must_equal "<!DOCTYPE html>\n<html>foo</html>\n"
+        .must_equal "<!DOCTYPE html><html>foo</html>"
 
       @s.document('<!DOCTYPE blah><html>foo</html>')
-        .must_equal "<!DOCTYPE html>\n<html>foo</html>\n"
+        .must_equal "<!DOCTYPE html><html>foo</html>"
 
       @s.document('<!DOCTYPE html BLAH "-//W3C//DTD HTML 4.01//EN"><html>foo</html>')
-        .must_equal "<!DOCTYPE html>\n<html>foo</html>\n"
+        .must_equal "<!DOCTYPE html><html>foo</html>"
 
       @s.document('<!whatever><html>foo</html>')
-        .must_equal "<html>foo</html>\n"
+        .must_equal "<html>foo</html>"
     end
 
     it 'should not allow doctype definitions in fragments' do

--- a/test/test_clean_element.rb
+++ b/test/test_clean_element.rb
@@ -21,7 +21,7 @@ describe 'Sanitize::Transformers::CleanElement' do
       :default    => 'Lorem dolor sit amet alert("hello world");',
       :restricted => 'Lorem <strong>dolor</strong> sit amet alert("hello world");',
       :basic      => 'Lorem <a href="pants" rel="nofollow"><strong>dolor</strong></a> sit<br>amet alert("hello world");',
-      :relaxed    => 'Lorem <a href="pants" title="foo&gt;ipsum &lt;a href="><strong>dolor</strong></a> sit<br>amet alert("hello world");',
+      :relaxed    => 'Lorem <a href="pants" title="foo>ipsum <a href="><strong>dolor</strong></a> sit<br>amet alert("hello world");',
     },
 
     :unclosed => {
@@ -234,7 +234,7 @@ describe 'Sanitize::Transformers::CleanElement' do
 
     it 'should not choke on valueless attributes' do
       @s.fragment('foo <a href>foo</a> bar')
-        .must_equal 'foo <a href rel="nofollow">foo</a> bar'
+        .must_equal 'foo <a href="" rel="nofollow">foo</a> bar'
     end
 
     it 'should downcase attribute names' do
@@ -262,7 +262,7 @@ describe 'Sanitize::Transformers::CleanElement' do
 
     it 'should encode special chars in attribute values' do
       @s.fragment('<a href="http://example.com" title="<b>&eacute;xamples</b> & things">foo</a>')
-        .must_equal '<a href="http://example.com" title="&lt;b&gt;éxamples&lt;/b&gt; &amp; things">foo</a>'
+        .must_equal '<a href="http://example.com" title="<b>éxamples</b> &amp; things">foo</a>'
     end
 
     strings.each do |name, data|

--- a/test/test_malicious_html.rb
+++ b/test/test_malicious_html.rb
@@ -43,7 +43,7 @@ describe 'Malicious HTML' do
   describe '<body>' do
     it 'should not be possible to inject JS via a malformed event attribute' do
       @s.document('<html><head></head><body onload!#$%&()*~+-_.,:;?@[/|\\]^`=alert("XSS")></body></html>').
-        must_equal "<html><head></head><body></body></html>\n"
+        must_equal "<html><head></head><body></body></html>"
     end
   end
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -32,21 +32,21 @@ describe 'Parser' do
   it 'should work around the libxml2 content-type meta tag bug' do
     Sanitize.document('<html><head></head><body>Howdy!</body></html>',
       :elements => %w[html head body]
-    ).must_equal "<html><head></head><body>Howdy!</body></html>\n"
+    ).must_equal "<html><head></head><body>Howdy!</body></html>"
 
     Sanitize.document('<html><head></head><body>Howdy!</body></html>',
       :elements => %w[html head meta body]
-    ).must_equal "<html><head></head><body>Howdy!</body></html>\n"
+    ).must_equal "<html><head></head><body>Howdy!</body></html>"
 
     Sanitize.document('<html><head><meta charset="utf-8"></head><body>Howdy!</body></html>',
       :elements   => %w[html head meta body],
       :attributes => {'meta' => ['charset']}
-    ).must_equal "<html><head><meta charset=\"utf-8\"></head><body>Howdy!</body></html>\n"
+    ).must_equal "<html><head><meta charset=\"utf-8\"></head><body>Howdy!</body></html>"
 
     Sanitize.document('<html><head><meta http-equiv="Content-Type" content="text/html;charset=utf-8"></head><body>Howdy!</body></html>',
       :elements   => %w[html head meta body],
       :attributes => {'meta' => %w[charset content http-equiv]}
-    ).must_equal "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html;charset=utf-8\"></head><body>Howdy!</body></html>\n"
+    ).must_equal "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html;charset=utf-8\"></head><body>Howdy!</body></html>"
 
     # Edge case: an existing content-type meta tag with a non-UTF-8 content type
     # will be converted to UTF-8, since that's the only output encoding we
@@ -54,7 +54,7 @@ describe 'Parser' do
     Sanitize.document('<html><head><meta http-equiv="content-type" content="text/html;charset=us-ascii"></head><body>Howdy!</body></html>',
       :elements   => %w[html head meta body],
       :attributes => {'meta' => %w[charset content http-equiv]}
-    ).must_equal "<html><head><meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\"></head><body>Howdy!</body></html>\n"
+    ).must_equal "<html><head><meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\"></head><body>Howdy!</body></html>"
   end
 
   describe 'when siblings are added after a node during traversal' do

--- a/test/test_sanitize.rb
+++ b/test/test_sanitize.rb
@@ -25,7 +25,7 @@ describe 'Sanitize' do
 
       it 'should sanitize an HTML document' do
         @s.document('<!doctype html><html><b>Lo<!-- comment -->rem</b> <a href="pants" title="foo">ipsum</a> <a href="http://foo.com/"><strong>dolor</strong></a> sit<br/>amet <script>alert("hello world");</script></html>')
-          .must_equal "<html>Lorem ipsum dolor sit amet alert(\"hello world\");</html>\n"
+          .must_equal "<html>Lorem ipsum dolor sit amet alert(\"hello world\");</html>"
       end
 
       it 'should not modify the input string' do
@@ -35,7 +35,7 @@ describe 'Sanitize' do
       end
 
       it 'should not choke on frozen documents' do
-        @s.document('<!doctype html><html><b>foo</b>'.freeze).must_equal "<html>foo</html>\n"
+        @s.document('<!doctype html><html><b>foo</b>'.freeze).must_equal "<html>foo</html>"
       end
     end
 

--- a/test/test_unicode.rb
+++ b/test/test_unicode.rb
@@ -23,61 +23,61 @@ describe 'Unicode' do
     end
 
     it 'should strip deprecated grave and acute clones' do
-      @s.document("a\u0340b\u0341c").must_equal "<html><head></head><body>abc</body></html>\n"
+      @s.document("a\u0340b\u0341c").must_equal "<html><head></head><body>abc</body></html>"
       @s.fragment("a\u0340b\u0341c").must_equal 'abc'
     end
 
     it 'should strip deprecated Khmer characters' do
-      @s.document("a\u17a3b\u17d3c").must_equal "<html><head></head><body>abc</body></html>\n"
+      @s.document("a\u17a3b\u17d3c").must_equal "<html><head></head><body>abc</body></html>"
       @s.fragment("a\u17a3b\u17d3c").must_equal 'abc'
     end
 
     it 'should strip line and paragraph separator punctuation' do
-      @s.document("a\u2028b\u2029c").must_equal "<html><head></head><body>abc</body></html>\n"
+      @s.document("a\u2028b\u2029c").must_equal "<html><head></head><body>abc</body></html>"
       @s.fragment("a\u2028b\u2029c").must_equal 'abc'
     end
 
     it 'should strip bidi embedding control characters' do
       @s.document("a\u202ab\u202bc\u202cd\u202de\u202e")
-        .must_equal "<html><head></head><body>abcde</body></html>\n"
+        .must_equal "<html><head></head><body>abcde</body></html>"
 
       @s.fragment("a\u202ab\u202bc\u202cd\u202de\u202e")
         .must_equal 'abcde'
     end
 
     it 'should strip deprecated symmetric swapping characters' do
-      @s.document("a\u206ab\u206bc").must_equal "<html><head></head><body>abc</body></html>\n"
+      @s.document("a\u206ab\u206bc").must_equal "<html><head></head><body>abc</body></html>"
       @s.fragment("a\u206ab\u206bc").must_equal 'abc'
     end
 
     it 'should strip deprecated Arabic form shaping characters' do
-      @s.document("a\u206cb\u206dc").must_equal "<html><head></head><body>abc</body></html>\n"
+      @s.document("a\u206cb\u206dc").must_equal "<html><head></head><body>abc</body></html>"
       @s.fragment("a\u206cb\u206dc").must_equal 'abc'
     end
 
     it 'should strip deprecated National digit shape characters' do
-      @s.document("a\u206eb\u206fc").must_equal "<html><head></head><body>abc</body></html>\n"
+      @s.document("a\u206eb\u206fc").must_equal "<html><head></head><body>abc</body></html>"
       @s.fragment("a\u206eb\u206fc").must_equal 'abc'
     end
 
     it 'should strip interlinear annotation characters' do
-      @s.document("a\ufff9b\ufffac\ufffb").must_equal "<html><head></head><body>abc</body></html>\n"
+      @s.document("a\ufff9b\ufffac\ufffb").must_equal "<html><head></head><body>abc</body></html>"
       @s.fragment("a\ufff9b\ufffac\ufffb").must_equal 'abc'
     end
 
     it 'should strip BOM/zero-width non-breaking space characters' do
-      @s.document("a\ufeffbc").must_equal "<html><head></head><body>abc</body></html>\n"
+      @s.document("a\ufeffbc").must_equal "<html><head></head><body>abc</body></html>"
       @s.fragment("a\ufeffbc").must_equal 'abc'
     end
 
     it 'should strip object replacement characters' do
-      @s.document("a\ufffcbc").must_equal "<html><head></head><body>abc</body></html>\n"
+      @s.document("a\ufffcbc").must_equal "<html><head></head><body>abc</body></html>"
       @s.fragment("a\ufffcbc").must_equal 'abc'
     end
 
     it 'should strip musical notation scoping characters' do
       @s.document("a\u{1d173}b\u{1d174}c\u{1d175}d\u{1d176}e\u{1d177}f\u{1d178}g\u{1d179}h\u{1d17a}")
-        .must_equal "<html><head></head><body>abcdefgh</body></html>\n"
+        .must_equal "<html><head></head><body>abcdefgh</body></html>"
 
       @s.fragment("a\u{1d173}b\u{1d174}c\u{1d175}d\u{1d176}e\u{1d177}f\u{1d178}g\u{1d179}h\u{1d17a}")
         .must_equal 'abcdefgh'
@@ -88,7 +88,7 @@ describe 'Unicode' do
       (0xE0000..0xE007F).each {|n| str << [n].pack('U') }
       str << 'b'
 
-      @s.document(str).must_equal "<html><head></head><body>ab</body></html>\n"
+      @s.document(str).must_equal "<html><head></head><body>ab</body></html>"
       @s.fragment(str).must_equal 'ab'
     end
   end


### PR DESCRIPTION
This can't be merged as is, but I wanted to share what I'd done, in case you want to update Nokogumbo to 2.0.

Nokogumbo 2.0 has had a bunch of fixes (many around errors which I don't think `sanitize` cares about), but it also does spec-compliant parsing of HTML fragments and serialization.

This changes a number of things as mentioned [here](https://github.com/rubys/nokogumbo/issues/69#issuecomment-428769534).

There are still 7 test failures with this PR, some of which I can explain, others I'm not sure why they're happening and I haven't investigated closely.

```
  1) Failure:
Malicious HTML::unsafe libxml2 server-side includes in attributes#test_0015_should not escape characters unnecessarily [/Users/steve/programming/sanitize/test/test_malicious_html.rb:182]:
--- expected
+++ actual
@@ -1 +1 @@
-"<div name='examp<!--\" onmouseover=alert(1)>-->le.com'>foo</div>"
+"<div name=\"examp<!--&quot; onmouseover=alert(1)>-->le.com\">foo</div>"


  2) Failure:
Transformers::YouTube transformer#test_0002_should allow HTTPS YouTube video embeds [/Users/steve/programming/sanitize/test/test_transformers.rb:181]:
--- expected
+++ actual
@@ -1 +1 @@
-"<iframe width=\"420\" height=\"315\" src=\"https://www.youtube.com/embed/QH2-TGUlwu4\" frameborder=\"0\" allowfullscreen=\"\">&lt;script&gt;alert()&lt;/script&gt;</iframe>"
+"<iframe width=\"420\" height=\"315\" src=\"https://www.youtube.com/embed/QH2-TGUlwu4\" frameborder=\"0\" allowfullscreen=\"\"><script>alert()</script></iframe>"


  3) Failure:
Transformers::YouTube transformer#test_0003_should allow protocol-relative YouTube video embeds [/Users/steve/programming/sanitize/test/test_transformers.rb:188]:
--- expected
+++ actual
@@ -1 +1 @@
-"<iframe width=\"420\" height=\"315\" src=\"//www.youtube.com/embed/QH2-TGUlwu4\" frameborder=\"0\" allowfullscreen=\"\">&lt;script&gt;alert()&lt;/script&gt;</iframe>"
+"<iframe width=\"420\" height=\"315\" src=\"//www.youtube.com/embed/QH2-TGUlwu4\" frameborder=\"0\" allowfullscreen=\"\"><script>alert()</script></iframe>"


  4) Failure:
Transformers::YouTube transformer#test_0004_should allow privacy-enhanced YouTube video embeds [/Users/steve/programming/sanitize/test/test_transformers.rb:195]:
--- expected
+++ actual
@@ -1 +1 @@
-"<iframe width=\"420\" height=\"315\" src=\"https://www.youtube-nocookie.com/embed/QH2-TGUlwu4\" frameborder=\"0\" allowfullscreen=\"\">&lt;script&gt;alert()&lt;/script&gt;</iframe>"
+"<iframe width=\"420\" height=\"315\" src=\"https://www.youtube-nocookie.com/embed/QH2-TGUlwu4\" frameborder=\"0\" allowfullscreen=\"\"><script>alert()</script></iframe>"


  5) Failure:
Transformers::YouTube transformer#test_0001_should allow HTTP YouTube video embeds [/Users/steve/programming/sanitize/test/test_transformers.rb:174]:
--- expected
+++ actual
@@ -1 +1 @@
-"<iframe width=\"420\" height=\"315\" src=\"http://www.youtube.com/embed/QH2-TGUlwu4\" frameborder=\"0\" allowfullscreen=\"\">&lt;script&gt;alert()&lt;/script&gt;</iframe>"
+"<iframe width=\"420\" height=\"315\" src=\"http://www.youtube.com/embed/QH2-TGUlwu4\" frameborder=\"0\" allowfullscreen=\"\"><script>alert()</script></iframe>"


  6) Failure:
Parser#test_0006_should work around the libxml2 content-type meta tag bug [/Users/steve/programming/sanitize/test/test_parser.rb:54]:
--- expected
+++ actual
@@ -1 +1 @@
-"<html><head><meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\"></head><body>Howdy!</body></html>"
+"<html><head><meta http-equiv=\"content-type\" content=\"text/html;charset=us-ascii\"></head><body>Howdy!</body></html>"


  7) Failure:
Sanitize::Transformers::CleanDoctype::when :allow_doctype is true#test_0001_should allow doctype declarations in documents [/Users/steve/programming/sanitize/test/test_clean_doctype.rb:39]:
--- expected
+++ actual
@@ -1 +1 @@
-"<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01//EN\"><html>foo</html>"
+"<!DOCTYPE html><html>foo</html>"
```

Failures 2–5 seem like pretty concerning failures. I'm not sure why that happens.

The HTML spec specifies that `"` in attribute values be escaped as `&quot;` and attribute values themselves are always surrounded by `"`. That explains Failure 1.

Libxml2 has the horrible behavior of inserting `meta` elements which you had code to remove. Nokogumbo 2.0 no longer uses libxml2's serialization (which is broken for HTML5 anyway, e.g., https://github.com/rubys/nokogumbo/issues/14). Nokogumbo no longer does anything with meta elements, hence Failure 6.

Finally, the HTML spec strips out public and system identifiers in DOCTYPEs when serializing. That explains Failure 7.

I have to run right this minute, but I'm happy to help make this work for you.