### PR TITLE
Add :parser_options config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,17 @@ elements not in this array will be removed.
 ]
 ```
 
+#### :parser_options (Hash)
+
+[Parsing options](https://github.com/rubys/nokogumbo/tree/v2.0.1#parsing-options) supplied to `nokogumbo`.
+
+```ruby
+:parser_options => {
+  max_errors: -1,
+  max_tree_depth: -1
+}
+```
+
 #### :protocols (Hash)
 
 URL protocols to allow in specific attributes. If an attribute is listed here

--- a/lib/sanitize.rb
+++ b/lib/sanitize.rb
@@ -121,7 +121,7 @@ class Sanitize
     return '' unless html
 
     html = preprocess(html)
-    frag  = Nokogiri::HTML5.fragment(html)
+    frag  = Nokogiri::HTML5.fragment(html, @config[:parser_options])
     node!(frag)
     to_html(frag)
   end

--- a/lib/sanitize/config/default.rb
+++ b/lib/sanitize/config/default.rb
@@ -56,6 +56,10 @@ class Sanitize
       # that all HTML will be stripped).
       :elements => [],
 
+      # Parsing options supplied to nokogumbo.
+      # https://github.com/rubys/nokogumbo/tree/v2.0.1#parsing-options
+      :parser_options => {},
+
       # URL handling protocols to allow in specific attributes. By default, no
       # protocols are allowed. Use :relative in place of a protocol if you want
       # to allow relative URLs sans protocol.

--- a/test/test_sanitize.rb
+++ b/test/test_sanitize.rb
@@ -61,6 +61,29 @@ describe 'Sanitize' do
       it 'should not choke on frozen fragments' do
         @s.fragment('<b>foo</b>'.freeze).must_equal 'foo'
       end
+
+      describe 'when html body exceeds Nokogumbo::DEFAULT_MAX_TREE_DEPTH' do
+        let(:content) do
+          content = nest_html_content('<b>foo</b>', Nokogumbo::DEFAULT_MAX_TREE_DEPTH)
+          "<body>#{content}</body>"
+        end
+
+        it 'raises an ArgumentError exception' do
+          assert_raises ArgumentError do
+            @s.fragment(content)
+          end
+        end
+
+        describe 'and :max_tree_depth of -1 is supplied in :parser_options' do
+          before do
+            @s = Sanitize.new(parser_options: { max_tree_depth: -1 })
+          end
+
+          it 'does not raise an ArgumentError exception' do
+            @s.fragment(content).must_equal 'foo'
+          end
+        end
+      end
     end
 
     describe '#node!' do
@@ -108,5 +131,11 @@ describe 'Sanitize' do
         end
       end
     end
+  end
+
+  private
+
+  def nest_html_content(html_content, depth)
+    "#{'<span>' * depth}#{html_content}#{'</span>' * depth}"
   end
 end


### PR DESCRIPTION
When `Sanitize.fragment` is called with a string representation of a html document that has nesting that exceeds [`Nokogumbo::DEFAULT_MAX_TREE_DEPTH` (400)](https://github.com/rubys/nokogumbo/blob/v2.0.1/lib/nokogumbo.rb#L13), the following exception is raised:
```
ArgumentError: Document tree depth limit exceeded
```
This pull request adds a new configuration option — `:parser_options`, that will be supplied to `nokogumbo` when calling `Nokogiri::HTML5.fragment`. The supported properties in `:parser_options` are documented [here](https://github.com/rubys/nokogumbo/tree/v2.0.1#parsing-options).