### PR TITLE
Update README to reflect the current default value for remove_contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ If this is an Array or Set of element names, then only the contents of the
 specified elements (when filtered) will be removed, and the contents of all
 other filtered elements will be left behind.
 
-The default value is `false`.
+The default value is `%w[iframe math noembed noframes noscript plaintext script style svg xmp]`.
 
 #### :transformers (Array or callable)
 


### PR DESCRIPTION
I noticed that the default value of `remove_contents` is no longer `false`, it became an array of element names in faf9a0f432fda3cef29f0f8aad99d4dedf079d67