### PR TITLE
Fix warning in Ruby 2.7+

### DIFF
--- a/lib/sanitize.rb
+++ b/lib/sanitize.rb
@@ -204,7 +204,7 @@ class Sanitize
       config[:node_name] = node.name.downcase
       config[:node_allowlist] = config[:node_whitelist] = node_allowlist
 
-      result = transformer.call(config)
+      result = transformer.call(**config)
 
       if result.is_a?(Hash)
         result_allowlist = result[:node_allowlist] || result[:node_whitelist]


### PR DESCRIPTION
This fixes the following warning when creating your own transformer like so:

```ruby
class SomeTransformer
  def call(node:, **_)
    {
      node_allowlist: [node],
    }
  end
end
```

```
/usr/local/bundle/ruby/2.7.0/gems/sanitize-5.2.1/lib/sanitize.rb:207: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```