### PR TITLE
ensure protocol processing happens on data attributes

### DIFF
--- a/lib/sanitize/transformers/clean_element.rb
+++ b/lib/sanitize/transformers/clean_element.rb
@@ -122,16 +122,15 @@ class Sanitize; module Transformers; class CleanElement
         unless attr_allowlist.include?(attr_name)
           # The attribute isn't allowed.
 
-          if allow_data_attributes && attr_name.start_with?('data-')
-            # Arbitrary data attributes are allowed. If this is a data
-            # attribute, continue.
-            next if attr_name =~ REGEX_DATA_ATTR
+          # Arbitrary data attributes are allowed. If this is a data
+          # attribute, continue.
+          unless allow_data_attributes && attr_name.start_with?('data-') &&
+            attr_name =~ REGEX_DATA_ATTR
+            # Either the attribute isn't a data attribute or arbitrary data
+            # attributes aren't allowed. Remove the attribute.
+            attr.unlink
+            next
           end
-
-          # Either the attribute isn't a data attribute or arbitrary data
-          # attributes aren't allowed. Remove the attribute.
-          attr.unlink
-          next
         end
 
         # The attribute is allowed.

--- a/test/test_clean_element.rb
+++ b/test/test_clean_element.rb
@@ -491,6 +491,22 @@ describe 'Sanitize::Transformers::CleanElement' do
       }).must_equal "<a>Text</a>"
     end
 
+    it 'should sanitize protocols in data attributes even if data attributes are generically allowed' do
+      input = '<a data-url="mailto:someone@example.com">Text</a>'
+
+      Sanitize.fragment(input, {
+        :elements => ['a'],
+        :attributes => {'a' => [:data]},
+        :protocols => {'a' => {'data-url' => ['https']}}
+      }).must_equal "<a>Text</a>"
+
+      Sanitize.fragment(input, {
+        :elements => ['a'],
+        :attributes => {'a' => [:data]},
+        :protocols => {'a' => {'data-url' => ['mailto']}}
+      }).must_equal input
+    end
+
     it 'should prevent `<meta>` tags from being used to set a non-UTF-8 charset' do
       Sanitize.document('<html><head><meta charset="utf-8"></head><body>Howdy!</body></html>',
         :elements   => %w[html head meta body],


### PR DESCRIPTION
this was broken in 4.6.3 by https://github.com/rgrove/sanitize/commit/01629a162e448a83d901456d0ba8b65f3b03d46e