### PR TITLE
Update to Nokogiri v1.12

### DIFF
--- a/lib/sanitize.rb
+++ b/lib/sanitize.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'nokogumbo'
+require 'nokogiri'
 require 'set'
 
 require_relative 'sanitize/version'

--- a/sanitize.gemspec
+++ b/sanitize.gemspec
@@ -18,8 +18,7 @@ Gem::Specification.new do |s|
 
   # Runtime dependencies.
   s.add_dependency('crass', '~> 1.0.2')
-  s.add_dependency('nokogiri', '>= 1.8.0')
-  s.add_dependency('nokogumbo', '~> 2.0')
+  s.add_dependency('nokogiri', '>= 1.12.0')
 
   # Development dependencies.
   s.add_development_dependency('minitest', '~> 5.11.3')

--- a/test/test_sanitize.rb
+++ b/test/test_sanitize.rb
@@ -53,9 +53,9 @@ describe 'Sanitize' do
         @s.document("a#{sample_non_chars}z").must_equal "<html>az</html>"
       end
 
-      describe 'when html body exceeds Nokogumbo::DEFAULT_MAX_TREE_DEPTH' do
+      describe 'when html body exceeds Nokogiri::Gumbo::DEFAULT_MAX_TREE_DEPTH' do
         let(:content) do
-          content = nest_html_content('<b>foo</b>', Nokogumbo::DEFAULT_MAX_TREE_DEPTH)
+          content = nest_html_content('<b>foo</b>', Nokogiri::Gumbo::DEFAULT_MAX_TREE_DEPTH)
           "<html>#{content}</html>"
         end
 
@@ -115,9 +115,9 @@ describe 'Sanitize' do
         @s.fragment("a#{sample_non_chars}z").must_equal "az"
       end
 
-      describe 'when html body exceeds Nokogumbo::DEFAULT_MAX_TREE_DEPTH' do
+      describe 'when html body exceeds Nokogiri::Gumbo::DEFAULT_MAX_TREE_DEPTH' do
         let(:content) do
-          content = nest_html_content('<b>foo</b>', Nokogumbo::DEFAULT_MAX_TREE_DEPTH)
+          content = nest_html_content('<b>foo</b>', Nokogiri::Gumbo::DEFAULT_MAX_TREE_DEPTH)
           "<body>#{content}</body>"
         end
 


### PR DESCRIPTION
Nokogiri v1.12 merged Nokogumbo code https://github.com/sparklemotion/nokogiri/releases/tag/v1.12.0

Therefore, Nokogumbo is not required as a dependency anymore.

If tests are run with latest Nokogiri, note about deprecation is printed:
```
NOTE: nokogumbo: Using Nokogiri::HTML5 provided by Nokogiri. See https://github.com/sparklemotion/nokogiri/issues/2205 for more information.
```