### PR TITLE
Add a couple of CSS properties to relaxed config

### DIFF
--- a/lib/sanitize/config/relaxed.rb
+++ b/lib/sanitize/config/relaxed.rb
@@ -666,7 +666,9 @@ class Sanitize
           text-decoration-color
           text-decoration-line
           text-decoration-skip
+          text-decoration-skip-ink
           text-decoration-style
+          text-decoration-thickness
           text-emphasis
           text-emphasis-color
           text-emphasis-position


### PR DESCRIPTION
Adding the newish CSS properties text-decoration-thickness and text-decoration-skip-ink to the relaxed allowlist. All the other text-decoration-* properties are already on the list, so this simply fixes that inconsistency.