### PR TITLE
Use 3.3 instead of ruby for ruby versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
           - '3.0'
           - '3.1'
           - '3.2'
-          - ruby
+          - '3.3'
           - ruby-head
           - truffleruby-head
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}


### PR DESCRIPTION
The 'ruby' version currently refers to version 3.3.x, but when the new 3.4.0 is released, our current setup will stop testing against 3.3.x. 

Therefore, I suggest we explicitly specify version 3.3 and, upon the release of 3.4.0, add and test against version 3.4 as well.

ref: https://github.com/rgrove/sanitize/pull/225#issuecomment-1671952525