### PR TITLE
Bump actions/checkout

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
           - truffleruby-head
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true


### PR DESCRIPTION
GitHub is [planning to upgrade to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/). Versions prior to actions/checkout v3 use an outdated version of node, so we will upgrade to actions/checkout v4, where [Node 20 is the default](https://github.com/actions/checkout/releases/tag/v4.0.0).