### PR TITLE
fix: set the DOCTYPE by removing the DTD and creating a new one

### DIFF
--- a/lib/sanitize/transformers/clean_doctype.rb
+++ b/lib/sanitize/transformers/clean_doctype.rb
@@ -9,7 +9,11 @@ class Sanitize; module Transformers
 
     if node.type == Nokogiri::XML::Node::DTD_NODE
       if env[:config][:allow_doctype]
-        node.name = 'html'
+        if node.name != "html"
+          document = node.document
+          node.unlink
+          document.create_internal_subset("html", nil, nil)
+        end
       else
         node.unlink
       end

--- a/sanitize.gemspec
+++ b/sanitize.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency('nokogiri', '>= 1.12.0')
 
   # Development dependencies.
-  s.add_development_dependency('minitest', '~> 5.14.4')
+  s.add_development_dependency('minitest', '~> 5.15') # needs to float to support ruby 2.5 and 3.4
   s.add_development_dependency('rake', '~> 13.0.6')
 
   s.require_paths = ['lib']


### PR DESCRIPTION
Set the DOCTYPE to "html" by removing the DTD and creating a new one.

GNOME/libxml2@8d0aaf4 prevents us from changing the node name in libxml >= 2.13.0.

See discussion in #3230 for context.