### PR TITLE
Add protocol allowlisting for -webkit-image-set CSS function

### DIFF
--- a/lib/sanitize/css.rb
+++ b/lib/sanitize/css.rb
@@ -272,7 +272,7 @@ class Sanitize; class CSS
             return nil unless valid_url?(child)
           end
 
-          if name == 'image-set' || name == 'image'
+          if ['image-set', 'image', '-webkit-image-set'].include?(name)
             return nil unless valid_image?(child)
           end
 
@@ -353,7 +353,7 @@ class Sanitize; class CSS
   # using an allowlisted protocol.
   def valid_image?(node)
     return false unless node[:node] == :function
-    return false unless node.key?(:name) && ['image', 'image-set'].include?(node[:name].downcase)
+    return false unless node.key?(:name) && ['image', 'image-set', '-webkit-image-set'].include?(node[:name].downcase)
     return false unless Array === node[:value]
 
     node[:value].each do |token|

--- a/test/test_sanitize_css.rb
+++ b/test/test_sanitize_css.rb
@@ -32,6 +32,9 @@ describe 'Sanitize::CSS' do
           "background: image-set('relative.jpg' 1x, 'relative-2x.jpg' 2x)",
           "background: image-set('https://example.com/https.jpg' 1x, 'https://example.com/https-2x.jpg' 2x)",
           "background: image-set('https://example.com/https.jpg' type('image/jpeg'), 'https://example.com/https.avif' type('image/avif'))",
+          "background: -webkit-image-set('relative.jpg' 1x, 'relative-2x.jpg' 2x)",
+          "background: -webkit-image-set('https://example.com/https.jpg' 1x, 'https://example.com/https-2x.jpg' 2x)",
+          "background: -webkit-image-set('https://example.com/https.jpg' type('image/jpeg'), 'https://example.com/https.avif' type('image/avif'))",
           "background: image('relative.jpg');",
           "background: image('https://example.com/https.jpg');",
           "background: image(rtl 'https://example.com/https.jpg');"


### PR DESCRIPTION
Builds on https://github.com/rgrove/sanitize/pull/240, providing protocol allowlisting coverage to the vendor prefixed version of `image-set`. 