### PR TITLE
Reduce gem size by excluding test files

### DIFF
--- a/sanitize.gemspec
+++ b/sanitize.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |s|
     "CHANGELOG.md",
     "LICENSE",
     "README.md"
-  ] + Dir.glob("lib/**/*.rb") + Dir.glob("test/**/*.rb")
+  ] + Dir.glob("lib/**/*.rb")
 end


### PR DESCRIPTION
This pull request updates the *.gemspec file to optimize the gem package size and structure

```bash
$ gem build -o before.tar.gz

$ git switch reduce-gem-size

$ gem build -o after.tar.gz

$ du -sh before.tar.gz after.tar.gz
 48K	before.tar.gz
 36K	after.tar.gz
 ```
 
| Metric | Before | After | Saved                 |
|--------|--------|-------|-----------------------|
| Size   | 48K    | 36K   | −12K (⏷ −25%)   |


###  whitch files was deleted?

```diff
data
 ├── CHANGELOG.md
 ├── lib
 │   ├── sanitize
 │   │   ├── config
 │   │   │   ├── basic.rb
 │   │   │   ├── default.rb
 │   │   │   ├── relaxed.rb
 │   │   │   └── restricted.rb
 │   │   ├── config.rb
 │   │   ├── css.rb
 │   │   ├── transformers
 │   │   │   ├── clean_cdata.rb
 │   │   │   ├── clean_comment.rb
 │   │   │   ├── clean_css.rb
 │   │   │   ├── clean_doctype.rb
 │   │   │   └── clean_element.rb
 │   │   └── version.rb
 │   └── sanitize.rb
 ├── LICENSE
 ├── README.md
-└── test
-    ├── common.rb
-    ├── test_clean_comment.rb
-    ├── test_clean_css.rb
-    ├── test_clean_doctype.rb
-    ├── test_clean_element.rb
-    ├── test_config.rb
-    ├── test_malicious_css.rb
-    ├── test_malicious_html.rb
-    ├── test_parser.rb
-    ├── test_sanitize_css.rb
-    ├── test_sanitize.rb
-    └── test_transformers.rb
```

ps: you can see on [rails repo](https://github.com/rails/rails/blob/main/actioncable/actioncable.gemspec#L20)